### PR TITLE
Give the option of storing values outside config.cson

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "fs-plus": "^2.2.3",
+    "season": "^1.0.2"
+  }
 }


### PR DESCRIPTION
Since these settings are mostly machine-specific and some people share their Atom configuration between machines through various mechanisms, this change makes it possible to store the Remember Window values outside the main configuration file. The default is to store the values as they always have been so that there is no change unless people specifically make the change.
